### PR TITLE
add delete_key to ets_backend and ConsulMutEx

### DIFF
--- a/lib/backends/ets_backend.ex
+++ b/lib/backends/ets_backend.ex
@@ -58,6 +58,17 @@ defmodule ConsulMutEx.Backends.ETSBackend do
   end
 
   @doc """
+  Delete a key
+  """
+  @spec delete_key(String.t, keyword()) :: :ok
+  def delete_key(key, opts \\ []) do
+     :ets.delete(@table, key)
+
+     :ok
+  end
+
+
+  @doc """
   Verify a lock.
   """
   @spec verify_lock(Lock.t) :: :ok | {:error, any()}

--- a/lib/consul_mut_ex.ex
+++ b/lib/consul_mut_ex.ex
@@ -82,6 +82,15 @@ defmodule ConsulMutEx do
   end
 
   @doc """
+  Delete a key
+  """
+  @spec delete_key(String.t, keyword()) :: :ok
+  def delete_key(key, opts \\ []) do
+    get_backend().delete_key(key, opts)
+  end
+
+
+  @doc """
   Initialize the configured backend.
 
   Note: This will be called when this application is started.

--- a/test/backends/consul_backend_test.exs
+++ b/test/backends/consul_backend_test.exs
@@ -69,7 +69,7 @@ defmodule ConsulMutEx.Backends.ConsulBackendTest do
     test "successfully deletes key" do
       key = new_key()
       {:error, _ } = Consul.Kv.fetch(key)
-      {:ok, lock} = ConsulBackend.acquire_lock(key)
+      {:ok, _lock} = ConsulBackend.acquire_lock(key)
       {:ok, _ } = Consul.Kv.fetch(key)
       :ok = ConsulBackend.delete_key(key)
       {:error, _ } = Consul.Kv.fetch(key)

--- a/test/backends/ets_backend_test.exs
+++ b/test/backends/ets_backend_test.exs
@@ -40,6 +40,16 @@ defmodule ConsulMutEx.Backends.ETSBackendTest do
     end
   end
 
+  describe "delete_key/2" do
+    test "successfully deletes key" do
+      key = new_key()
+      {:ok, _lock} = ETSBackend.acquire_lock(key)
+      assert :error == ETSBackend.acquire_lock(key, max_retries: 0)
+      assert :ok == ETSBackend.delete_key(key)
+      assert {:ok, _lock2} = ETSBackend.acquire_lock(key)
+    end
+  end
+
   describe "verify_lock/1" do
     test "successfully verifies lock" do
       {:ok, lock} = ETSBackend.acquire_lock(new_key())


### PR DESCRIPTION
I added `delete_key` to `consul_backend` and this PR adds `delete_key` to the `ets_backend` to have feature parity in `ConsulMutEx`